### PR TITLE
解决“设置页面关闭卡槽信息，同时使用默认模板时，发送消息卡槽信息仍显示”

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/model/vo/SmsVo.java
+++ b/app/src/main/java/com/idormy/sms/forwarder/model/vo/SmsVo.java
@@ -59,11 +59,12 @@ public class SmsVo implements Serializable {
         boolean switchSmsTemplate = SettingUtil.getSwitchSmsTemplate();
         String smsTemplate = SettingUtil.getSmsTemplate().trim();
         String deviceMark = SettingUtil.getAddExtraDeviceMark().trim();
-        if (!switchAddExtra) {
-            smsTemplate = smsTemplate.replace("{{卡槽信息}}\n", "").replace("{{卡槽信息}}", "");
-        }
         if (!switchSmsTemplate) {
             smsTemplate = "{{来源号码}}\n{{短信内容}}\n{{卡槽信息}}\n{{接收时间}}\n{{设备名称}}";
+        }
+
+        if (!switchAddExtra) {
+            smsTemplate = smsTemplate.replace("{{卡槽信息}}\n", "").replace("{{卡槽信息}}", "");
         }
 
         return smsTemplate.replace("{{来源号码}}", mobile)

--- a/app/src/main/java/com/idormy/sms/forwarder/utils/SimUtil.java
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/SimUtil.java
@@ -49,7 +49,7 @@ public class SimUtil {
             Log.d(TAG, "getSimExtra Fail: " + e.getMessage());
         }
 
-        return 0;
+        return 1;
     }
 
 


### PR DESCRIPTION
默认设置下（不转发卡槽信息、默认模板），卡槽信息不应该显示
