### PR TITLE
修复：更换SIM卡后，卡槽信息仍是上一张卡

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/MyApplication.java
+++ b/app/src/main/java/com/idormy/sms/forwarder/MyApplication.java
@@ -4,10 +4,12 @@ import android.app.ActivityManager;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.util.Log;
 
+import com.idormy.sms.forwarder.receiver.SimStateReceiver;
 import com.idormy.sms.forwarder.sender.SendHistory;
 import com.idormy.sms.forwarder.service.BatteryService;
 import com.idormy.sms.forwarder.service.FrontService;
@@ -69,6 +71,10 @@ public class MyApplication extends Application {
             //电池状态监听
             Intent batteryServiceIntent = new Intent(this, BatteryService.class);
             startService(batteryServiceIntent);
+
+            //SIM卡插拔状态广播监听
+            IntentFilter simStateFilter = new IntentFilter(SimStateReceiver.ACTION_SIM_STATE_CHANGED);
+            registerReceiver(new SimStateReceiver(), simStateFilter);
 
             //友盟统计
             sharedPreferencesHelper = new SharedPreferencesHelper(this, "umeng");

--- a/app/src/main/java/com/idormy/sms/forwarder/receiver/SimStateReceiver.java
+++ b/app/src/main/java/com/idormy/sms/forwarder/receiver/SimStateReceiver.java
@@ -1,0 +1,41 @@
+package com.idormy.sms.forwarder.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.idormy.sms.forwarder.MyApplication;
+import com.idormy.sms.forwarder.utils.PhoneUtils;
+
+public class SimStateReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "SimStateReceiver";
+    public static final String ACTION_SIM_STATE_CHANGED = "android.intent.action.SIM_STATE_CHANGED";
+    private static final String EXTRA_SIM_STATE = "ss";
+    private static final String SIM_STATE_LOADED = "LOADED";
+
+    /**
+     * 更换SIM卡，如果不杀后台并重启，则发送出的「卡槽信息」仍然是刚启动应用时读取的SIM卡
+     * 增加这个Receiver，接收SIM卡插拔状态广播，自动更新缓存
+     *
+     * @param context
+     * @param intent
+     */
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String receiveAction = intent.getAction();
+        Log.d(TAG, "onReceive intent " + receiveAction);
+        if (ACTION_SIM_STATE_CHANGED.equals(receiveAction)) {
+            //SIM状态的额外信息
+            String state = intent.getExtras().getString(EXTRA_SIM_STATE);
+            Log.d(TAG, state);
+            //只需要最后一个SIM加载完毕的 LOADED 状态
+            if (SIM_STATE_LOADED.equals(state)) {
+                //刷新SimInfoList
+                MyApplication.SimInfoList = PhoneUtils.getSimMultiInfo();
+                Log.d(TAG, MyApplication.SimInfoList.toString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
更换SIM卡，并清空SIM卡备注后（或从未设置备注），如果不杀后台并重启，则发送出的「卡槽信息」仍然是刚启动应用时读取的SIM卡