### PR TITLE
修复：降级Android Gradle插件版本以兼容4.4

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -11,7 +11,7 @@ ext.build_versions = build_versions
 
 ext.deps = [:]
 def versions = [:]
-versions.android_gradle_plugin = '7.3.1'
+versions.android_gradle_plugin = '7.2.2'
 versions.android_maven_gradle_plugin = "2.1"
 versions.gradle_bintray_plugin = "1.8.0"
 versions.booster = "3.1.0"


### PR DESCRIPTION
## 问题
在Android 4.4上运行最新的v3.1.1版会报错：java.lang.VerifyError: org/conscrypt/Platform

## 复现步骤
- 在Android 4.4.4上安装apk
- 运行app，增加短信通道，选择webhook输入网址后点击测试，app会完全崩溃
- 查看logcat可观察到最原始的exception为java.lang.VerifyError: org/conscrypt/Platform

## 修复
参考issue如下，目前的workaround为降级Gradle Android plugin的版本或关闭proguard的minifyEnabled，考虑后决定是是降级Gradle为7.2.2
- https://github.com/google/conscrypt/issues/1085

经过blame versions.gradle发现从3.0.1开始gradle的安卓插件版本就在7.3以上了，所以请 @pppscn 大佬注意以后不要轻易升级gradle的各种版本