### PR TITLE
修复：错误的 URL 有效性验证正则表达式

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/utils/CommonUtils.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/CommonUtils.kt
@@ -211,7 +211,7 @@ class CommonUtils private constructor() {
         //是否合法的url
         fun checkUrl(urls: String?, emptyResult: Boolean): Boolean {
             if (TextUtils.isEmpty(urls)) return emptyResult
-            val regex = "^(https?|ftp|file)://[-a-zA-Z\\d+&@#/%?=~_|!:,.;\\[\\]]*[-a-zA-Z\\d+&@#/%=~_|\\[\\]]"
+            val regex = "^https?://(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
             val pat = Pattern.compile(regex)
             val mat = pat.matcher(urls?.trim() ?: "")
             return mat.matches()


### PR DESCRIPTION
我在导入飞书机器人的时候遇到了提示 Webhook URL 无效的问题，检查了代码发现用于验证 URL 的正则应该是错误的，因此有了这个 PR。

请见[当前正则的测试](https://regex101.com/r/NyMfAv/2)以及[新正则的测试](https://regex101.com/r/3cBJGH/1)。

注意这个 PR 去掉了 `ftp` 和 `file` 两个协议，如果这个是必须的话，可能要更新一下正则。