### PR TITLE
添加卡槽信息获取补偿机制,修复远程发短信指定卡不明确问题

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/utils/PhoneUtils.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/PhoneUtils.kt
@@ -47,7 +47,7 @@ class PhoneUtils private constructor() {
                     println("1.版本超过5.1，调用系统方法")
                     val mSubscriptionManager = XUtil.getContext().getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager
                     ActivityCompat.checkSelfPermission(
-                        XUtil.getContext(), permission.READ_PHONE_STATE
+                            XUtil.getContext(), permission.READ_PHONE_STATE
                     )
                     val activeSubscriptionInfoList: List<SubscriptionInfo>? = mSubscriptionManager.activeSubscriptionInfoList
                     if (activeSubscriptionInfoList != null && activeSubscriptionInfoList.isNotEmpty()) {
@@ -69,9 +69,9 @@ class PhoneUtils private constructor() {
                     val uri = Uri.parse("content://telephony/siminfo") //访问raw_contacts表
                     val resolver: ContentResolver = XUtil.getContext().contentResolver
                     val cursor = resolver.query(
-                        uri, arrayOf(
+                            uri, arrayOf(
                             "_id", "icc_id", "sim_id", "display_name", "carrier_name", "name_source", "color", "number", "display_number_format", "data_roaming", "mcc", "mnc"
-                        ), null, null, null
+                    ), null, null, null
                     )
                     if (cursor != null && cursor.moveToFirst()) {
                         do {
@@ -90,6 +90,57 @@ class PhoneUtils private constructor() {
                 }
             } catch (e: java.lang.Exception) {
                 e.printStackTrace()
+            }
+            //仍然获取不到/只获取到一个->取出备注
+            if (infoList.isEmpty() || infoList.size == 1) {
+                println("3.直接取出备注框的数据作为信息")
+                //为空，两个卡都没有获取到信息
+                if (infoList.isEmpty()) {
+                    //卡1备注信息不为空
+                    var etExtraSim1 = SettingUtils.extraSim1
+                    if (!TextUtils.isEmpty(etExtraSim1)) {
+                        val simInfo1 = SimInfo()
+                        //卡1
+                        simInfo1.mSimSlotIndex = 0
+                        simInfo1.mNumber = etExtraSim1
+                        simInfo1.mSubscriptionId = SettingUtils.subidSim1
+                        //把卡放入
+                        infoList[simInfo1.mSimSlotIndex] = simInfo1
+                    }
+                    //卡2备注信息不为空
+                    var etExtraSim2 = SettingUtils.extraSim2
+                    if (!TextUtils.isEmpty(etExtraSim2)) {
+                        val simInfo2 = SimInfo()
+                        simInfo2.mSimSlotIndex = 1
+                        simInfo2.mNumber = etExtraSim2
+                        simInfo2.mSubscriptionId = SettingUtils.subidSim2
+                        //把卡放入
+                        infoList[simInfo2.mSimSlotIndex] = simInfo2
+                    }
+
+                    //有一张卡,判断是卡几
+                } else {
+                    var infoListIndex = -1;
+                    for (obj in infoList) {
+                        infoListIndex = obj.key
+                    }
+                    //获取到卡1，且卡2备注信息不为空
+                    if (infoListIndex == 0 && !TextUtils.isEmpty(SettingUtils.extraSim2)) {
+                        //获取到卡1信息，卡2备注不为空，创建卡2实体
+                        val simInfo2 = SimInfo()
+                        simInfo2.mSimSlotIndex = 1
+                        simInfo2.mNumber = SettingUtils.extraSim2
+                        simInfo2.mSubscriptionId = SettingUtils.subidSim1
+                        infoList[simInfo2.mSimSlotIndex] = simInfo2
+                    } else if (infoListIndex == 1 && !TextUtils.isEmpty(SettingUtils.extraSim1)) {
+                        //获取到卡2信息，卡1备注不为空，创建卡1实体
+                        val simInfo1 = SimInfo()
+                        simInfo1.mSimSlotIndex = 0
+                        simInfo1.mNumber = SettingUtils.extraSim1
+                        simInfo1.mSubscriptionId = SettingUtils.subidSim1
+                        infoList[simInfo1.mSimSlotIndex] = simInfo1
+                    }
+                }
             }
             Log.e(TAG, infoList.toString())
             return infoList
@@ -126,7 +177,7 @@ class PhoneUtils private constructor() {
                     val sendPI = PendingIntent.getBroadcast(XUtil.getContext(), 0, Intent(), sendFlags)
 
                     val smsManager = if (subId > -1 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) SmsManager.getSmsManagerForSubscriptionId(
-                        subId
+                            subId
                     ) else SmsManager.getDefault()
                     // Android 5.1.1 以下使用反射指定卡槽
                     if (subId > -1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
@@ -141,7 +192,7 @@ class PhoneUtils private constructor() {
                     if (message.length >= 70) {
                         val deliverFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) PendingIntent.FLAG_IMMUTABLE else 0
                         val deliverPI = PendingIntent.getBroadcast(
-                            XUtil.getContext(), 0, Intent("DELIVERED_SMS_ACTION"), deliverFlags
+                                XUtil.getContext(), 0, Intent("DELIVERED_SMS_ACTION"), deliverFlags
                         )
 
                         val sentPendingIntents = ArrayList<PendingIntent>()
@@ -153,7 +204,7 @@ class PhoneUtils private constructor() {
                             deliveredPendingIntents.add(i, deliverPI)
                         }
                         smsManager.sendMultipartTextMessage(
-                            mobile, null, divideContents, sentPendingIntents, deliveredPendingIntents
+                                mobile, null, divideContents, sentPendingIntents, deliveredPendingIntents
                         )
                     } else {
                         smsManager.sendTextMessage(mobile, null, message, sendPI, null)
@@ -169,7 +220,7 @@ class PhoneUtils private constructor() {
 
         //获取通话记录列表
         fun getCallInfoList(
-            type: Int, limit: Int, offset: Int, phoneNumber: String?
+                type: Int, limit: Int, offset: Int, phoneNumber: String?
         ): MutableList<CallInfo> {
             val callInfoList: MutableList<CallInfo> = mutableListOf()
             try {
@@ -188,7 +239,7 @@ class PhoneUtils private constructor() {
 
                 //为了兼容性这里全部取出后手动分页
                 val cursor = Core.app.contentResolver.query(
-                    CallLog.Calls.CONTENT_URI, null, selection, selectionArgs.toTypedArray(), CallLog.Calls.DEFAULT_SORT_ORDER // + " limit $limit offset $offset"
+                        CallLog.Calls.CONTENT_URI, null, selection, selectionArgs.toTypedArray(), CallLog.Calls.DEFAULT_SORT_ORDER // + " limit $limit offset $offset"
                 ) ?: return callInfoList
                 Log.i(TAG, "cursor count:" + cursor.count)
 
@@ -229,14 +280,14 @@ class PhoneUtils private constructor() {
                     do {
                         if (curOffset >= offset) {
                             val callInfo = CallInfo(
-                                cursor.getString(indexName) ?: "",  //姓名
-                                cursor.getString(indexNumber) ?: "",  //号码
-                                cursor.getLong(indexDate),  //获取通话日期
-                                cursor.getInt(indexDuration),  //获取通话时长，值为多少秒
-                                cursor.getInt(indexType),  //获取通话类型：1.呼入 2.呼出 3.未接
-                                if (indexViaNumber != -1) cursor.getString(indexViaNumber) else "",  //来源号码
-                                if (indexSimId != -1) getSimId(cursor.getInt(indexSimId), isSimId) else -1,  //卡槽ID： 0=Sim1, 1=Sim2, -1=获取失败
-                                if (indexSubId != -1) cursor.getInt(indexSubId) else 0,  //卡槽主键
+                                    cursor.getString(indexName) ?: "",  //姓名
+                                    cursor.getString(indexNumber) ?: "",  //号码
+                                    cursor.getLong(indexDate),  //获取通话日期
+                                    cursor.getInt(indexDuration),  //获取通话时长，值为多少秒
+                                    cursor.getInt(indexType),  //获取通话类型：1.呼入 2.呼出 3.未接
+                                    if (indexViaNumber != -1) cursor.getString(indexViaNumber) else "",  //来源号码
+                                    if (indexSimId != -1) getSimId(cursor.getInt(indexSimId), isSimId) else -1,  //卡槽ID： 0=Sim1, 1=Sim2, -1=获取失败
+                                    if (indexSubId != -1) cursor.getInt(indexSubId) else 0,  //卡槽主键
                             )
                             Log.d(TAG, callInfo.toString())
                             callInfoList.add(callInfo)
@@ -267,7 +318,7 @@ class PhoneUtils private constructor() {
 
         //获取联系人列表
         fun getContactInfoList(
-            limit: Int, offset: Int, phoneNumber: String?, name: String?
+                limit: Int, offset: Int, phoneNumber: String?, name: String?
         ): MutableList<ContactInfo> {
             val contactInfoList: MutableList<ContactInfo> = mutableListOf()
 
@@ -286,7 +337,7 @@ class PhoneUtils private constructor() {
                 Log.d(TAG, "selectionArgs = $selectionArgs")
 
                 val cursor = Core.app.contentResolver.query(
-                    ContactsContract.CommonDataKinds.Phone.CONTENT_URI, null, selection, selectionArgs.toTypedArray(), ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY
+                        ContactsContract.CommonDataKinds.Phone.CONTENT_URI, null, selection, selectionArgs.toTypedArray(), ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY
                 ) ?: return contactInfoList
                 Log.i(TAG, "cursor count:" + cursor.count)
 
@@ -301,8 +352,8 @@ class PhoneUtils private constructor() {
                     val mobileNoIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
                     do {
                         val contactInfo = ContactInfo(
-                            cursor.getString(displayNameIndex),  //姓名
-                            cursor.getString(mobileNoIndex),  //号码
+                                cursor.getString(displayNameIndex),  //姓名
+                                cursor.getString(mobileNoIndex),  //号码
                         )
                         Log.d(TAG, contactInfo.toString())
                         contactInfoList.add(contactInfo)
@@ -333,9 +384,9 @@ class PhoneUtils private constructor() {
             sb.append(ResUtils.getString(R.string.linkman)).append(callInfo.name).append("\n")
             if (!TextUtils.isEmpty(callInfo.viaNumber)) sb.append(ResUtils.getString(R.string.via_number)).append(callInfo.viaNumber).append("\n")
             if (callInfo.dateLong > 0L) sb.append(ResUtils.getString(R.string.call_date)).append(
-                DateUtils.millis2String(
-                    callInfo.dateLong, SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-                )
+                    DateUtils.millis2String(
+                            callInfo.dateLong, SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+                    )
             ).append("\n")
             if (callInfo.duration > 0) {
                 if (callInfo.type == 3) {
@@ -361,7 +412,7 @@ class PhoneUtils private constructor() {
 
         // 获取用户短信列表
         fun getSmsInfoList(
-            type: Int, limit: Int, offset: Int, keyword: String
+                type: Int, limit: Int, offset: Int, keyword: String
         ): MutableList<SmsInfo> {
             val smsInfoList: MutableList<SmsInfo> = mutableListOf()
             try {
@@ -380,7 +431,7 @@ class PhoneUtils private constructor() {
 
                 // 避免超过总数后循环取出
                 val cursorTotal = Core.app.contentResolver.query(
-                    Uri.parse("content://sms/"), null, selection, selectionArgs.toTypedArray(), "date desc"
+                        Uri.parse("content://sms/"), null, selection, selectionArgs.toTypedArray(), "date desc"
                 ) ?: return smsInfoList
                 if (offset >= cursorTotal.count) {
                     cursorTotal.close()
@@ -388,7 +439,7 @@ class PhoneUtils private constructor() {
                 }
 
                 val cursor = Core.app.contentResolver.query(
-                    Uri.parse("content://sms/"), null, selection, selectionArgs.toTypedArray(), "date desc limit $limit offset $offset"
+                        Uri.parse("content://sms/"), null, selection, selectionArgs.toTypedArray(), "date desc limit $limit offset $offset"
                 ) ?: return smsInfoList
 
                 Log.i(TAG, "cursor count:" + cursor.count)


### PR DESCRIPTION
![image](https://0927.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2Fc9a280b3-17ee-4fe6-9976-498928664d26%2FUntitled.png?id=d7c2bef3-fa65-488e-bed9-78cd9d6c612e&table=block&spaceId=8b0312a6-2d13-4463-9bbf-800dd3cd01e2&width=2000&userId=&cache=v2)


![image](https://0927.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F66231e95-d1f0-41fd-b745-38b56247586b%2FUntitled.png?id=baa63f55-9f1a-4b92-9246-99ef7a37999b&table=block&spaceId=8b0312a6-2d13-4463-9bbf-800dd3cd01e2&width=2000&userId=&cache=v2)

![image](https://0927.notion.site/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F9627f832-78e9-4061-9ca4-c9a7f37ce7a9%2FUntitled.png?id=2e0c81ed-0ede-4b27-9e4d-8935ff52da51&table=block&spaceId=8b0312a6-2d13-4463-9bbf-800dd3cd01e2&width=2000&userId=&cache=v2)

借助刷新按钮，无法过去卡槽信息的设备，

通过自行备注sim卡信息后，解决了

短信转发过程中，{{卡槽信息}}变量的正确赋值

但是会产生。远程发短信，无法确定sim卡，问题

也就是，远程发短信，

不管用sim卡1、2发送，因使用的原有的逻辑无法获取sim卡subid，

从而导致默认使用卡1发送，（远程操作卡2发送的信息也会是卡1发出）



另外由于使用idea的代码格式化，导致多处代码被重新格式化，出现多处代码修改
请慎重考虑本次PR是否MR