### PR TITLE
新增：App通知转发增加uid条件，区分双开应用（需Android Q）

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/database/AppDatabase.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/database/AppDatabase.kt
@@ -15,7 +15,7 @@ import com.idormy.sms.forwarder.utils.DATABASE_NAME
 @Database(
     entities = [Frpc::class, Msg::class, Logs::class, Rule::class, Sender::class],
     views = [LogsDetail::class],
-    version = 17,
+    version = 18,
     exportSchema = false
 )
 @TypeConverters(ConvertersDate::class)
@@ -98,6 +98,7 @@ custom_domains = smsf.demo.com
                     MIGRATION_14_15,
                     MIGRATION_15_16,
                     MIGRATION_16_17,
+                    MIGRATION_17_18
                 )
 
             /*if (BuildConfig.DEBUG) {
@@ -378,6 +379,13 @@ CREATE TABLE "Logs" (
         private val MIGRATION_16_17 = object : Migration(16, 17) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("Alter table Msg add column call_type INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        //规则配置增加uid条件
+        private val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("Alter table rule add column uid INTEGER NOT NULL DEFAULT 0 ")
             }
         }
 

--- a/app/src/main/java/com/idormy/sms/forwarder/database/entity/Rule.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/database/entity/Rule.kt
@@ -51,6 +51,7 @@ data class Rule(
     //免打扰(禁用转发)时间段
     @ColumnInfo(name = "silent_period_start", defaultValue = "0") var silentPeriodStart: Int = 0,
     @ColumnInfo(name = "silent_period_end", defaultValue = "0") var silentPeriodEnd: Int = 0,
+    @ColumnInfo(name = "uid", defaultValue = "0") var uid: Int = 0,
 ) : Parcelable {
 
     companion object {
@@ -158,6 +159,10 @@ data class Rule(
         //检查这一行和上一行合并的结果是否命中
         var mixChecked = false
         if (msg != null) {
+            if(this.uid != 0 && msg.uid != this.uid){
+                Log.i(TAG, "rule:$this checkMsg:$msg checked:false")
+                return false
+            }
             //先检查规则是否命中
             when (this.filed) {
                 FILED_TRANSPOND_ALL -> mixChecked = true

--- a/app/src/main/java/com/idormy/sms/forwarder/entity/MsgInfo.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/entity/MsgInfo.kt
@@ -27,6 +27,7 @@ data class MsgInfo(
     var simSlot: Int = -1, //卡槽id：-1=获取失败、0=卡槽1、1=卡槽2
     var subId: Int = 0, //卡槽主键
     var callType: Int = 0, //通话类型：1.来电挂机 2.去电挂机 3.未接来电 4.来电提醒 5.来电接通 6.去电拨出
+    var uid: Int = 0,
 ) : Serializable {
 
     val titleForSend: String

--- a/app/src/main/java/com/idormy/sms/forwarder/fragment/RulesEditFragment.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/fragment/RulesEditFragment.kt
@@ -130,6 +130,7 @@ class RulesEditFragment : BaseFragment<FragmentRulesEditBinding?>(), View.OnClic
                 initAppSpinner()
                 //监听已安装App信息列表加载完成事件
                 LiveEventBus.get(EVENT_LOAD_APP_LIST, String::class.java).observeStickyForever(appListObserver)
+                binding!!.layoutUid.visibility = View.VISIBLE
             }
 
             "call" -> {
@@ -157,6 +158,7 @@ class RulesEditFragment : BaseFragment<FragmentRulesEditBinding?>(), View.OnClic
                     binding!!.spCallType.selectedIndex = callTypeIndex
                 }
                 binding!!.spCallType.selectedIndex = callTypeIndex
+                binding!!.layoutUid.visibility = View.GONE
             }
 
             else -> {
@@ -167,6 +169,7 @@ class RulesEditFragment : BaseFragment<FragmentRulesEditBinding?>(), View.OnClic
                 binding!!.btInsertSenderApp.visibility = View.GONE
                 binding!!.btInsertTitleApp.visibility = View.GONE
                 binding!!.btInsertContentApp.visibility = View.GONE
+                binding!!.layoutUid.visibility = View.GONE
             }
         }
 
@@ -592,7 +595,7 @@ class RulesEditFragment : BaseFragment<FragmentRulesEditBinding?>(), View.OnClic
                 binding!!.sbStatus.isChecked = rule.statusChecked
                 silentPeriodStart = rule.silentPeriodStart
                 silentPeriodEnd = rule.silentPeriodEnd
-
+                binding!!.etUid.setText(rule.uid.toString())
                 //初始化发送通道下拉框
                 initSenderSpinner()
             }
@@ -659,8 +662,29 @@ class RulesEditFragment : BaseFragment<FragmentRulesEditBinding?>(), View.OnClic
         //if (status == STATUS_OFF) {
         //    throw Exception(getString(R.string.invalid_rule_status))
         //}
-
-        return Rule(ruleId, ruleType, filed, check, value, senderId, smsTemplate, regexReplace, simSlot, status, Date(), senderListSelected, senderLogic, silentPeriodStart, silentPeriodEnd)
+        val uidText = binding!!.etUid.text
+        var uid = 0
+        if(uidText!=null&& uidText.isNotEmpty()){
+            uid = uidText.toString().toInt()
+        }
+        return Rule(
+            ruleId,
+            ruleType,
+            filed,
+            check,
+            value,
+            senderId,
+            smsTemplate,
+            regexReplace,
+            simSlot,
+            status,
+            Date(),
+            senderListSelected,
+            senderLogic,
+            silentPeriodStart,
+            silentPeriodEnd,
+            uid
+        )
     }
 
     //检查多重匹配规则是否正确

--- a/app/src/main/java/com/idormy/sms/forwarder/service/NotifyService.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/service/NotifyService.kt
@@ -127,7 +127,10 @@ class NotifyService : NotificationListenerService() {
             if (TextUtils.isEmpty(title) && TextUtils.isEmpty(text)) return
 
             val msgInfo = MsgInfo("app", from, text, Date(), title, -1)
-
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                Log.d(TAG, "消息的UID====>" + sbn.uid)
+                msgInfo.uid = sbn.uid
+            }
             //TODO：自动消除通知（临时方案，重复查询换取准确性）
             if (SettingUtils.enableCancelAppNotify) {
                 val ruleList: List<Rule> = Core.rule.getRuleList(msgInfo.type, 1, "SIM0")

--- a/app/src/main/res/layout/fragment_rules_edit.xml
+++ b/app/src/main/res/layout/fragment_rules_edit.xml
@@ -144,6 +144,28 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/layoutUid"
+                style="@style/ruleBarStyleWithSwitch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="5dp"
+                    android:text="@string/uid"
+                    android:textStyle="bold" />
+
+                <com.xuexiang.xui.widget.edittext.materialedittext.MaterialEditText
+                    android:id="@+id/et_uid"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    app:met_clearButton="true" />
+
+            </LinearLayout>
+            <LinearLayout
                 style="@style/ruleBarStyleWithSwitch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -200,7 +222,6 @@
                 </RadioGroup>
 
             </LinearLayout>
-
             <LinearLayout
                 android:id="@+id/layout_match_type"
                 style="@style/ruleBarStyle"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1072,4 +1072,5 @@
 
     <string name="enable_location_tag">Enable {{LOCATION}} Tag</string>
     <string name="enable_location_tag_tips">Insert location info into forwarded msg.</string>
+    <string name="uid">UID</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1073,4 +1073,5 @@
 
     <string name="enable_location_tag">启用 {{定位信息}} 标签</string>
     <string name="enable_location_tag_tips">在转发信息中插入手机的当前定位信息</string>
+    <string name="uid">UID</string>
 </resources>


### PR DESCRIPTION
给App通知转发的规则增加了uid配置（默认为0，不对uid进行判断），双开应用可以通过区分通知的uid走不同的转发通道。
目前仅实现可配置并匹配uid，具体app的uid自行查询。