### PR TITLE
修复：`蓝牙服务未开启`时提示语

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
@@ -614,9 +614,9 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
         if (!initViewsFinished) return
         Log.d(TAG, "restartBluetoothService, action: $action")
         val serviceIntent = Intent(requireContext(), BluetoothScanService::class.java)
-        //如果定位功能已启用，但是系统定位功能不可用，则关闭定位功能
+        //如果蓝牙功能已启用，但是系统蓝牙功能不可用，则关闭蓝牙功能
         if (SettingUtils.enableBluetooth && (!BluetoothUtils.isBluetoothEnabled() || !BluetoothUtils.hasBluetoothCapability(App.context))) {
-            XToastUtils.error(getString(R.string.toast_location_not_enabled))
+            XToastUtils.error(getString(R.string.toast_bluetooth_not_enabled))
             SettingUtils.enableBluetooth = false
             binding!!.sbEnableBluetooth.isChecked = false
             binding!!.layoutBluetoothSetting.visibility = View.GONE

--- a/app/src/main/res/layout/fragment_tasks_condition_charge.xml
+++ b/app/src/main/res/layout/fragment_tasks_condition_charge.xml
@@ -45,7 +45,7 @@
                     android:id="@+id/tv_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/task_battery_tips"
+                    android:text="@string/task_charge_tips"
                     android:textSize="@dimen/text_size_mini"
                     tools:ignore="SmallSp" />
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1109,6 +1109,7 @@
     <string name="chat_id">Chat ID</string>
     <string name="receive_id">Receive ID</string>
     <string name="toast_location_not_enabled">Location is not enabled, Please go to system settings and activate it.</string>
+    <string name="toast_bluetooth_not_enabled">Bluetooth is not enabled, Please go to system settings and activate it.</string>
     <string name="task_condition_check_again">Recheck when delaying execution.</string>
     <string name="task_condition_check_again_tips">When used as a triggering condition, recheck during delayed action execution.</string>
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -940,6 +940,7 @@
     <string name="task_charge">Charge</string>
     <string name="task_lock_screen">Screen Off/On</string>
     <string name="task_lock_screen_tips">Trigger upon screen lock/unlock instantly or after a set time.</string>
+    <string name="task_charge_tips">Triggered when the charging state meets the conditions.</string>
     <string name="task_sms">SMS</string>
     <string name="task_sms_when">received SMS broadcast from %s</string>
     <string name="task_call">Call</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -939,6 +939,7 @@
     <string name="task_battery">电量使用</string>
     <string name="task_battery_tips">当剩余电量满足条件时触发</string>
     <string name="task_charge">充电状态</string>
+    <string name="task_charge_tips">当充电状态满足条件时触发</string>
     <string name="task_lock_screen">锁屏解锁</string>
     <string name="task_lock_screen_tips">在屏幕锁定或解锁后立即或指定时间触发</string>
     <string name="task_sms">短信广播</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1110,6 +1110,7 @@
     <string name="chat_id">Chat ID</string>
     <string name="receive_id">消息接收者ID</string>
     <string name="toast_location_not_enabled">位置服务未开启，请先前往系统设置中开启！</string>
+    <string name="toast_bluetooth_not_enabled">蓝牙服务未开启，请先前往系统设置中开启！</string>
     <string name="task_condition_check_again">延迟执行时再次校验</string>
     <string name="task_condition_check_again_tips">作为触发条件时，在延迟执行动作时再次校验是否满足</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1110,6 +1110,7 @@
     <string name="chat_id">Chat ID</string>
     <string name="receive_id">訊息接收者ID</string>
     <string name="toast_location_not_enabled">定位服務未開啟，請先前往系統設置中開啟！</string>
+    <string name="toast_bluetooth_not_enabled">藍牙服務未開啟，請先前往系統設置中開啟！</string>
     <string name="task_condition_check_again">延遲執行時再次校驗</string>
     <string name="task_condition_check_again_tips">作為觸發條件時，在延遲執行動作時再次校驗是否滿足</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -939,6 +939,7 @@
     <string name="task_battery">電量使用</string>
     <string name="task_battery_tips">當剩餘電量滿足條件時觸發</string>
     <string name="task_charge">充電狀態</string>
+    <string name="task_charge_tips">當充電狀態滿足條件時觸發</string>
     <string name="task_lock_screen">鎖屏解鎖</string>
     <string name="task_lock_screen_tips">在屏幕鎖定或解鎖後立即或指定時間觸發</string>
     <string name="task_sms">簡訊廣播</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -966,6 +966,7 @@
     <string name="task_battery">电量使用</string>
     <string name="task_battery_tips">当剩余电量满足条件时触发</string>
     <string name="task_charge">充电状态</string>
+    <string name="task_charge_tips">当充电状态满足条件时触发</string>
     <string name="task_lock_screen">锁屏解锁</string>
     <string name="task_lock_screen_tips">在屏幕锁定或解锁后立即或指定时间触发</string>
     <string name="task_sms">短信广播</string>


### PR DESCRIPTION
`主界面->通用设置->打开“发现蓝牙设备服务”`时，如果蓝牙服务未开启会出现类型为toast的错误提示，而提示的文本与其后的开关“GPS定位服务”打开时如果定位服务未开启时所出现的同类型提示文本一致（值为`位置服务未开启，请先前往系统设置中开启！`），引用地址一致，且并没有正确的“发现蓝牙设备服务”的引用目标

https://github.com/pppscn/SmsForwarder/assets/99505726/28d68492-913f-4c70-9b95-d7ea347e1f64

