### PR TITLE
优化：兼容Server酱³Sendkey

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/utils/sender/ServerchanUtils.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/sender/ServerchanUtils.kt
@@ -38,7 +38,14 @@ class ServerchanUtils {
                 msgInfo.getContentForSend(SettingUtils.smsTemplate)
             }
 
-            val requestUrl: String = String.format("https://sctapi.ftqq.com/%s.send", setting.sendKey) //推送地址
+            // 兼容Server酱³Sendkey，使用正则表达式提取数字部分
+            val matchResult = Regex("^sctp(\\d+)t", RegexOption.IGNORE_CASE).find(setting.sendKey)
+            val requestUrl = if (matchResult != null && matchResult.groups[1] != null) {
+                "https://${matchResult.groups[1]?.value}.push.ft07.com/send/${setting.sendKey}.send"
+            } else {
+                String.format("https://sctapi.ftqq.com/%s.send", setting.sendKey) // 默认推送地址
+            }
+            
             Log.i(TAG, "requestUrl:$requestUrl")
 
             val request = XHttp.post(requestUrl)


### PR DESCRIPTION
JS逻辑如下：

```js
const matchResult = String(notification.serverChanSendKey).match(/^sctp(\d+)t/i);
const url = matchResult && matchResult[1]
? `https://${matchResult[1]}.push.ft07.com/send/${notification.serverChanSendKey}.send`
: `https://sctapi.ftqq.com/${notification.serverChanSendKey}.send`;
```

kotlin不太熟，用GPT改了一个版本，测试了下应该没有语法错。

```kotlin
 // 兼容Server酱³Sendkey，使用正则表达式提取数字部分
val matchResult = Regex("^sctp(\\d+)t", RegexOption.IGNORE_CASE).find(setting.sendKey)
val requestUrl = if (matchResult != null && matchResult.groups[1] != null) {
  "https://${matchResult.groups[1]?.value}.push.ft07.com/send/${setting.sendKey}.send"
  } else {
  String.format("https://sctapi.ftqq.com/%s.send", setting.sendKey) // 默认推送地址
}
```