### PR TITLE
修复：tip_can_not_get_sim_info 格式化占位符错误

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -512,7 +512,7 @@
     <string name="no">No</string>
     <string name="refresh">Refresh</string>
     <string name="tip_can_not_get_sim_infos">Please confirm that the app permission [Get mobile phone information] is [Always allow]</string>
-    <string name="tip_can_not_get_sim_info">The SIM card information in the card slot %s has not been obtained</string>
+    <string name="tip_can_not_get_sim_info">The SIM card information in the card slot %d has not been obtained</string>
     <string name="auto_check">Auto check</string>
     <string name="check_update">Check</string>
     <string name="join_preview_program">Join Preview Program</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -513,7 +513,7 @@
     <string name="no">No</string>
     <string name="refresh">刷新</string>
     <string name="tip_can_not_get_sim_infos">无法获取卡槽信息，请确认应用权限【获取手机信息】为【始终允许】</string>
-    <string name="tip_can_not_get_sim_info">未获取到卡槽%s中的SIM卡信息</string>
+    <string name="tip_can_not_get_sim_info">未获取到卡槽%d中的SIM卡信息</string>
     <string name="auto_check">启动时检查</string>
     <string name="check_update">检查更新</string>
     <string name="join_preview_program">加入SmsF预览体验计划</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -513,7 +513,7 @@
     <string name="no">No</string>
     <string name="refresh">刷新</string>
     <string name="tip_can_not_get_sim_infos">無法獲取卡槽信息，請確認應用權限【獲取手機信息】為【始終允許】</string>
-    <string name="tip_can_not_get_sim_info">未獲取到卡槽%s中的SIM卡信息</string>
+    <string name="tip_can_not_get_sim_info">未獲取到卡槽%d中的SIM卡信息</string>
     <string name="auto_check">啟動時檢查</string>
     <string name="check_update">檢查更新</string>
     <string name="join_preview_program">加入SmsF預覽體驗計劃</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -540,7 +540,7 @@
     <string name="no">No</string>
     <string name="refresh">刷新</string>
     <string name="tip_can_not_get_sim_infos">无法获取卡槽信息，请确认应用权限【获取手机信息】为【始终允许】</string>
-    <string name="tip_can_not_get_sim_info">未获取到卡槽%s中的SIM卡信息</string>
+    <string name="tip_can_not_get_sim_info">未获取到卡槽%d中的SIM卡信息</string>
     <string name="auto_check">启动时检查</string>
     <string name="check_update">检查更新</string>
     <string name="join_preview_program">加入SmsF预览体验计划</string>


### PR DESCRIPTION
**没有测试！没有测试！没有测试！**

这个字符串是 "未获取到卡槽%s中的SIM卡信息"。工程里都是类似这样使用的`String.format(getString(R.string.tip_can_not_get_sim_info), 1)`。
这个 %s 貌似写错了，数字的话应该用 %d 才对。