### PR TITLE
优化：单 sim 卡槽手机不显示 sim2 设置。

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
@@ -180,12 +180,18 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
         editAddExtraDeviceMark(binding!!.etExtraDeviceMark)
         //SIM1主键
         editAddSubidSim1(binding!!.etSubidSim1)
-        //SIM2主键
-        editAddSubidSim2(binding!!.etSubidSim2)
         //SIM1备注
         editAddExtraSim1(binding!!.etExtraSim1)
-        //SIM2备注
-        editAddExtraSim2(binding!!.etExtraSim2)
+
+        // sim 槽只有一个的时候不显示 SIM2 设置
+        if (PhoneUtils.getSimSlotCount() != 1) {
+            //SIM2主键
+            editAddSubidSim2(binding!!.etSubidSim2)
+            //SIM2备注
+            editAddExtraSim2(binding!!.etExtraSim2)
+        } else {
+            binding!!.layoutSim2.visibility = View.GONE
+        }
         //通知内容
         editNotifyContent(binding!!.etNotifyContent)
         //启用自定义模版

--- a/app/src/main/java/com/idormy/sms/forwarder/utils/PhoneUtils.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/PhoneUtils.kt
@@ -14,6 +14,7 @@ import android.provider.Settings
 import android.telephony.SmsManager
 import android.telephony.SubscriptionInfo
 import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
 import android.text.TextUtils
 import androidx.annotation.RequiresPermission
 import androidx.core.app.ActivityCompat
@@ -36,6 +37,14 @@ class PhoneUtils private constructor() {
 
     companion object {
         const val TAG = "PhoneUtils"
+
+        /** 获取 sim 卡槽数量，注意不是 sim 卡的数量。*/
+        fun getSimSlotCount() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+            (App.context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager).activeModemCount
+        else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            (App.context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager).phoneCount
+        else
+            -1
 
         //获取多卡信息
         @SuppressLint("Range")

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1567,6 +1567,7 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/layout_sim2"
                 style="@style/BarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
像 Pixel 5 这种手机是单卡槽的，从物理上就插不了两个 sim 卡。但在通用设置-个性设置里却还有 sim2 的设置项。

<img width="481" alt="image" src="https://github.com/user-attachments/assets/4798fb44-cda8-4e57-a349-b23e389196b9">

个人认为可以把这里优化掉，在只有一个卡槽的时候就不显示 sim2 的设置项了。问了下 GPT，发现可以用TelephonyManager 的 `activeModemCount`（api level 30+）或 `phoneCount` (api level 24~29) 方法获取到卡槽数量。不过工程最低 level 是 19，这部分我就没处理。