### PR TITLE
优化：SIM 主键初始化 toString 告警消除

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
@@ -991,7 +991,7 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
 
     //设置SIM1主键
     private fun editAddSubidSim1(etSubidSim1: EditText) {
-        etSubidSim1.setText(SettingUtils.subidSim1.toString())
+        etSubidSim1.setText("${SettingUtils.subidSim1}")
         etSubidSim1.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
@@ -1008,7 +1008,7 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
 
     //设置SIM2主键
     private fun editAddSubidSim2(etSubidSim2: EditText) {
-        etSubidSim2.setText(SettingUtils.subidSim2.toString())
+        etSubidSim2.setText("${SettingUtils.subidSim2}")
         etSubidSim2.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}


### PR DESCRIPTION
这页的 SIM 主键初始化的逻辑 Android Studio 误判了，老是告警，挺烦的。给改成字符串插值的形式了。

![image](https://github.com/user-attachments/assets/f154abb6-c588-460d-978e-4be2ba27cf0b)