### PR TITLE
优化：红米手机开机启动提示问题

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
@@ -1206,6 +1206,7 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
             "huawei" -> getString(R.string.auto_start_huawei)
             "honor" -> getString(R.string.auto_start_honor)
             "xiaomi" -> getString(R.string.auto_start_xiaomi)
+            "redmi" -> getString(R.string.auto_start_redmi)
             "oppo" -> getString(R.string.auto_start_oppo)
             "vivo" -> getString(R.string.auto_start_vivo)
             "meizu" -> getString(R.string.auto_start_meizu)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1143,4 +1143,5 @@
     <string name="bluetooth_not_supported">Bluetooth not supported.</string>
     <string name="start_discovery">Discovery</string>
     <string name="invalid_bluetooth_mac_address">Bluetooth Mac Address is invalid, eg. AA:BB:CC:DD:EE:FF</string>
+    <string name="auto_start_redmi"><![CDATA[RedMi: Authorization Management -> Self-Start Management -> Allow Apps to Self-Start]]></string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1144,4 +1144,5 @@
     <string name="bluetooth_not_supported">不支持蓝牙设备</string>
     <string name="start_discovery">搜索设备</string>
     <string name="invalid_bluetooth_mac_address">蓝牙设备MAC地址无效，例如：AA:BB:CC:DD:EE:FF</string>
+    <string name="auto_start_redmi"><![CDATA[红米手机：授权管理 -> 自启动管理 -> 允许应用自启动]]></string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1144,4 +1144,5 @@
     <string name="bluetooth_not_supported">不支援藍牙裝置</string>
     <string name="start_discovery">搜索裝置</string>
     <string name="invalid_bluetooth_mac_address">藍牙裝置MAC地址無效，例如：AA:BB:CC:DD:EE:FF</string>
+    <string name="auto_start_redmi"><![CDATA[紅米手機：授權管理 -> 自啟動管理 -> 允許應用自啟動]]></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1171,4 +1171,5 @@
     <string name="bluetooth_not_supported">不支持蓝牙设备</string>
     <string name="start_discovery">搜索设备</string>
     <string name="invalid_bluetooth_mac_address">蓝牙设备MAC地址无效，例如：AA:BB:CC:DD:EE:FF</string>
+    <string name="auto_start_redmi"><![CDATA[红米手机：授权管理 -> 自启动管理 -> 允许应用自启动]]></string>
 </resources>


### PR DESCRIPTION
红米手机在设置页的开机启动提示中还是显示未知品牌。
![image](https://github.com/user-attachments/assets/d19808c9-554e-4fda-89c6-06f9c11e3fcc)
具体手机型号如下
* 手机型号：Redmi Note 11 5G
* 系统版本：Xiaomi HyperOS 1.0.1.0.TGBCNXM
* 底层安卓版本：13

研究了下，发现红米手机上 build 对应信息是这样的：
```java
Build.BRAND = 'Redmi'
Build.MANUFACTURER = "Xiaomi"
```
也就是说只改个提示就行，具体的开启启动逻辑复用小米的就行。实际运行了下也是这样的。现在是这样的。
![image](https://github.com/user-attachments/assets/4db61346-107c-4206-99b3-72fa613b4352)