### PR TITLE
新增 靠近听筒关屏 功能

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/App.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/App.kt
@@ -50,6 +50,7 @@ import com.idormy.sms.forwarder.utils.FRPC_LIB_VERSION
 import com.idormy.sms.forwarder.utils.HistoryUtils
 import com.idormy.sms.forwarder.utils.HttpServerUtils
 import com.idormy.sms.forwarder.utils.Log
+import com.idormy.sms.forwarder.utils.ProximitySensorScreenHelper
 import com.idormy.sms.forwarder.utils.SettingUtils
 import com.idormy.sms.forwarder.utils.SharedPreference
 import com.idormy.sms.forwarder.utils.sdkinit.UMengInit
@@ -263,7 +264,8 @@ class App : Application(), CactusCallback, Configuration.Provider by Core {
                 addAction(Intent.ACTION_USER_PRESENT)
             }
             registerReceiver(lockScreenReceiver, lockScreenFilter)
-
+            //靠近听筒关屏
+            ProximitySensorScreenHelper.refresh(this)
             //Cactus 集成双进程前台服务，JobScheduler，onePix(一像素)，WorkManager，无声音乐
             if (SettingUtils.enableCactus) {
                 //注册广播监听器

--- a/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/fragment/SettingsFragment.kt
@@ -61,6 +61,7 @@ import com.idormy.sms.forwarder.utils.KeepAliveUtils
 import com.idormy.sms.forwarder.utils.LocationUtils
 import com.idormy.sms.forwarder.utils.Log
 import com.idormy.sms.forwarder.utils.PhoneUtils
+import com.idormy.sms.forwarder.utils.ProximitySensorScreenHelper
 import com.idormy.sms.forwarder.utils.SettingUtils
 import com.idormy.sms.forwarder.utils.XToastUtils
 import com.idormy.sms.forwarder.widget.GuideTipsDialog
@@ -149,6 +150,8 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
         switchEnableLocation(binding!!.sbEnableLocation, binding!!.layoutLocationSetting, binding!!.rgAccuracy, binding!!.rgPowerRequirement, binding!!.xsbMinInterval, binding!!.xsbMinDistance)
         //短信指令
         switchEnableSmsCommand(binding!!.sbEnableSmsCommand, binding!!.etSafePhone)
+        //靠近听筒关屏
+        switchEnableCloseToEarpieceTurnOffScreen(binding!!.layoutEnableCloseToEarpieceTurnOffScreen, binding!!.sbEnableCloseToEarpieceTurnOffScreen)
         //启动时异步获取已安装App信息
         switchEnableLoadAppList(binding!!.sbEnableLoadAppList, binding!!.scbLoadUserApp, binding!!.scbLoadSystemApp)
         //设置自动消除额外APP通知
@@ -763,6 +766,23 @@ class SettingsFragment : BaseFragment<FragmentSettingsBinding?>(), View.OnClickL
                 SettingUtils.smsCommandSafePhone = etSafePhone.text.toString().trim().removeSuffix("\n")
             }
         })
+    }
+
+    //靠近听筒关屏
+    private fun switchEnableCloseToEarpieceTurnOffScreen(
+        layoutEnableCloseToEarpieceTurnOffScreen: View,
+        sbEnableCloseToEarpieceTurnOffScreen: SwitchButton
+    ) {
+        if (!ProximitySensorScreenHelper.isEnable()) {
+            layoutEnableCloseToEarpieceTurnOffScreen.visibility = View.GONE
+            return
+        }
+        sbEnableCloseToEarpieceTurnOffScreen.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
+            SettingUtils.enableCloseToEarpieceTurnOffScreen = isChecked
+            ProximitySensorScreenHelper.refresh(requireContext().applicationContext)
+        }
+        sbEnableCloseToEarpieceTurnOffScreen.isChecked =
+            SettingUtils.enableCloseToEarpieceTurnOffScreen
     }
 
     //设置自动消除额外APP通知

--- a/app/src/main/java/com/idormy/sms/forwarder/utils/Constants.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/Constants.kt
@@ -53,6 +53,7 @@ const val SP_CANCEL_EXTRA_APP_NOTIFY = "cancel_extra_app_notify_list"
 const val SP_ENABLE_NOT_USER_PRESENT = "enable_not_user_present"
 
 const val SP_ENABLE_SMS_COMMAND = "enable_sms_command"
+const val SP_ENABLE_CLOSE_TO_EARPIECE_TURN_OFF_SCREEN = "enable_close_2_earpiece_turn_off_screen"
 const val SP_SMS_COMMAND_SAFE_PHONE = "sms_command_safe_phone"
 
 const val ENABLE_LOAD_APP_LIST = "enable_load_app_list"

--- a/app/src/main/java/com/idormy/sms/forwarder/utils/ProximitySensorScreenHelper.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/ProximitySensorScreenHelper.kt
@@ -1,0 +1,90 @@
+package com.idormy.sms.forwarder.utils
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Build
+import android.os.PowerManager
+
+
+object ProximitySensorScreenHelper {
+    private var mProximityWakeLock: PowerManager.WakeLock? = null
+    private var sensorEventListener: SensorEventListener? = null
+
+    fun refresh(context: Context) {
+        if (SettingUtils.enableCloseToEarpieceTurnOffScreen) {
+            if (mProximityWakeLock == null) {
+                start(context)
+            }
+        } else {
+            if (mProximityWakeLock != null) {
+                stop(context)
+            }
+        }
+    }
+
+    fun isEnable() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+
+    private fun start(context: Context) {
+        if (!isEnable()) {
+            return
+        }
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        if (powerManager.isWakeLockLevelSupported(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK)) {
+            mProximityWakeLock = powerManager.newWakeLock(
+                PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK,
+                "smsForwarder:ProximitySensorScreenHelper"
+            )
+        } else {
+            mProximityWakeLock = null
+        }
+        mProximityWakeLock?.also { wakeLock ->
+            val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+            val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY) ?: return
+            sensorEventListener = object : SensorEventListener {
+                override fun onSensorChanged(event: SensorEvent?) {
+                    val its = event?.values ?: return
+                    if (event.sensor.type == Sensor.TYPE_PROXIMITY) {
+                        //经过测试，当手贴近距离感应器的时候its[0]返回值为0.0，当手离开时返回1.0
+                        if (its[0] == 0.0f) { // 贴近手机
+                            if (wakeLock.isHeld) {
+                                return
+                            }
+                            wakeLock.acquire() // 申请设备电源锁
+                        } else { // 远离手机
+                            if (!wakeLock.isHeld) {
+                                return
+                            }
+                            wakeLock.release() // 释放设备电源锁
+                        }
+                    }
+                }
+
+                override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+
+                }
+            }
+            sensorManager.registerListener(
+                sensorEventListener,
+                sensor,
+                SensorManager.SENSOR_DELAY_NORMAL
+            )
+        }
+    }
+
+    private fun stop(context: Context) {
+        sensorEventListener?.also {
+            val sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+            sensorManager.unregisterListener(it)
+        }
+        sensorEventListener = null
+        mProximityWakeLock?.also { wakeLock ->
+            if (wakeLock.isHeld) {
+                wakeLock.release()
+            }
+        }
+        mProximityWakeLock = null
+    }
+}

--- a/app/src/main/java/com/idormy/sms/forwarder/utils/SettingUtils.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/SettingUtils.kt
@@ -47,6 +47,9 @@ class SettingUtils private constructor() {
         var enableSmsCommand: Boolean by SharedPreference(SP_ENABLE_SMS_COMMAND, false)
         var smsCommandSafePhone: String by SharedPreference(SP_SMS_COMMAND_SAFE_PHONE, "")
 
+        //是否靠近听筒关屏
+        var enableCloseToEarpieceTurnOffScreen: Boolean by SharedPreference(SP_ENABLE_CLOSE_TO_EARPIECE_TURN_OFF_SCREEN, false)
+
         //是否转发应用通知——自动消除通知
         var enableCancelAppNotify: Boolean by SharedPreference(SP_ENABLE_CANCEL_APP_NOTIFY, false)
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -744,6 +744,44 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/layout_enable_close_to_earpiece_turn_off_screen"
+                style="@style/BarStyle.Switch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/close_to_earpiece_turn_off_screen"
+                        android:textStyle="bold"
+                        tools:ignore="RelativeOverlap" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/close_to_earpiece_turn_off_screen_tips"
+                        android:textSize="@dimen/text_size_mini"
+                        tools:ignore="SmallSp" />
+
+                </LinearLayout>
+
+                <com.xuexiang.xui.widget.button.switchbutton.SwitchButton
+                    android:id="@+id/sb_enable_close_to_earpiece_turn_off_screen"
+                    style="@style/SwitchButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:ignore="TouchTargetSizeCheck" />
+
+            </LinearLayout>
+
+            <LinearLayout
                 style="@style/BarStyle.Switch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -336,6 +336,8 @@
     <string name="forward_sms_tips">Main switch, requires permissions to read and sned SMS messages, especially verification SMS texts.</string>
     <string name="sms_command">Sms Command</string>
     <string name="sms_command_tips">Open the HttpServer or FRPC by the SMS command</string>
+    <string name="close_to_earpiece_turn_off_screen">Close to the earpiece and turn off the screen</string>
+    <string name="close_to_earpiece_turn_off_screen_tips">After manually closing the system timeout lock screen, cover the earpiece to turn off the screen and maintain the wake-up state</string>
     <string name="safe_phone_tips">Only handle requests from specified phones</string>
     <string name="forward_calls">Forward Calls Log</string>
     <string name="forward_calls_tips">Main switch, requires permissions to read call log and contacts.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -337,6 +337,8 @@
     <string name="forward_sms_tips">请授予读取短信、通知类短信、发送短信等权限，关闭验证码保护</string>
     <string name="sms_command">短信指令</string>
     <string name="sms_command_tips">根据短信指令开关对应功能，指令格式：smsf#功能名#动作名</string>
+    <string name="close_to_earpiece_turn_off_screen">靠近听筒关屏</string>
+    <string name="close_to_earpiece_turn_off_screen_tips">手动关闭系统超时锁屏后，盖住听筒即可关屏并保持唤醒状态</string>
     <string name="safe_phone_tips">仅处理指定手机请求，多个手机以逗号分隔</string>
     <string name="forward_calls">转发通话记录</string>
     <string name="forward_calls_tips">请授予读取通话记录、联系人等权限，并选择转发类型，再开启</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -337,6 +337,8 @@
     <string name="forward_sms_tips">請授予讀取簡訊、通知類簡訊、發送簡訊等權限，關閉驗證碼保護</string>
     <string name="sms_command">簡訊指令</string>
     <string name="sms_command_tips">根據簡訊指令開關對應功能，指令格式：smsf#功能名#動作名</string>
+    <string name="close_to_earpiece_turn_off_screen">靠近聽筒關屏</string>
+    <string name="close_to_earpiece_turn_off_screen_tips">手動關閉系統超時鎖屏後，蓋住聽筒即可關屏並保持喚醒狀態</string>
     <string name="safe_phone_tips">僅處理指定手機請求，多個手機以逗號分隔</string>
     <string name="forward_calls">轉發通話記錄</string>
     <string name="forward_calls_tips">請授予讀取通話記錄、聯繫人等權限，並選擇轉發類型，再開啟</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,6 +366,8 @@
     <string name="forward_sms_tips">请授予读取短信、通知类短信、发送短信等权限，关闭验证码保护</string>
     <string name="sms_command">短信指令</string>
     <string name="sms_command_tips">根据短信指令开关对应功能，指令格式：smsf#功能名#动作名</string>
+    <string name="close_to_earpiece_turn_off_screen">靠近听筒关屏</string>
+    <string name="close_to_earpiece_turn_off_screen_tips">手动关闭系统超时锁屏后，盖住听筒即可关屏并保持唤醒状态</string>
     <string name="safe_phone_tips">仅处理指定手机请求，多个手机以逗号分隔</string>
     <string name="forward_calls">转发通话记录</string>
     <string name="forward_calls_tips">请授予读取通话记录、联系人等权限，并选择转发类型，再开启</string>


### PR DESCRIPTION
新增“靠近听筒关屏”功能，当用户手动关闭系统超时锁屏后，盖住听筒即可关屏并保持唤醒状态，防止系统因锁屏进入休眠状态而导致监听不及时