### PR TITLE
信息链接增加变量标签支持

### DIFF
--- a/app/src/main/java/com/idormy/sms/forwarder/utils/sender/BarkUtils.kt
+++ b/app/src/main/java/com/idormy/sms/forwarder/utils/sender/BarkUtils.kt
@@ -67,7 +67,11 @@ class BarkUtils {
             if (!TextUtils.isEmpty(setting.level)) msgMap["level"] = setting.level
             if (!TextUtils.isEmpty(setting.sound)) msgMap["sound"] = setting.sound
             if (!TextUtils.isEmpty(setting.badge)) msgMap["badge"] = setting.badge
-            if (!TextUtils.isEmpty(setting.url)) msgMap["url"] = setting.url
+            if (!TextUtils.isEmpty(setting.url)) {
+                val replacedUrl = msgInfo.getContentForSend(setting.url)
+                msgMap["url"] = replacedUrl
+            }
+
             if (!TextUtils.isEmpty(setting.call)) msgMap["call"] = setting.call
 
             //自动复制


### PR DESCRIPTION

对于ios bark，使url带变量标签。。场景：备用机未接来电，主机接到推送可一键回拨。url://{{FROM}}.
![IMG_20250419_215723](https://github.com/user-attachments/assets/8f8997fb-2477-4009-a922-b33fc6af633c)
![11 (3)](https://github.com/user-attachments/assets/beff786e-23a4-4d74-95d2-fc7e2bb30119)


