### PR TITLE
修复：锁屏时及时调度短信转发任务

### DIFF
--- a/app/src/main/kotlin/cn/ppps/forwarder/receiver/SmsReceiver.kt
+++ b/app/src/main/kotlin/cn/ppps/forwarder/receiver/SmsReceiver.kt
@@ -4,7 +4,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.provider.Telephony
+import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.google.gson.Gson
@@ -18,6 +20,19 @@ import cn.ppps.forwarder.utils.Worker
 import cn.ppps.forwarder.workers.SendWorker
 import com.xuexiang.xrouter.utils.TextUtils
 import java.util.Date
+
+internal fun buildSmsSendWorkRequest(
+    msgInfoJson: String,
+    enqueuedAt: Long = System.currentTimeMillis(),
+): OneTimeWorkRequest = OneTimeWorkRequestBuilder<SendWorker>()
+    .setInputData(
+        workDataOf(
+            Worker.SEND_MSG_INFO to msgInfoJson,
+            Worker.SEND_ENQUEUED_AT to enqueuedAt,
+        )
+    )
+    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+    .build()
 
 //短信广播
 @Suppress("PrivatePropertyName", "UNUSED_PARAMETER")
@@ -109,11 +124,7 @@ class SmsReceiver : BroadcastReceiver() {
             val msgInfo = MsgInfo("sms", from, msg, Date(), simInfo, simSlot, subscription)
             Log.d(TAG, "msgInfo = $msgInfo")
 
-            val request = OneTimeWorkRequestBuilder<SendWorker>().setInputData(
-                workDataOf(
-                    Worker.SEND_MSG_INFO to Gson().toJson(msgInfo)
-                )
-            ).build()
+            val request = buildSmsSendWorkRequest(Gson().toJson(msgInfo))
             WorkManager.getInstance(context).enqueue(request)
 
         } catch (e: Exception) {

--- a/app/src/main/kotlin/cn/ppps/forwarder/utils/Constants.kt
+++ b/app/src/main/kotlin/cn/ppps/forwarder/utils/Constants.kt
@@ -2,6 +2,7 @@ package cn.ppps.forwarder.utils
 
 object Worker {
     const val SEND_MSG_INFO = "send_msg_info"
+    const val SEND_ENQUEUED_AT = "send_enqueued_at"
     const val UPDATE_LOGS = "update_logs"
     const val RULE = "rule"
     const val SENDER_INDEX = "sender_index"
@@ -155,6 +156,8 @@ const val TYPE_SOCKET = 15
 const val FRONT_NOTIFY_ID = 0x1010
 const val FRONT_CHANNEL_ID = "cn.ppps.forwarder"
 const val FRONT_CHANNEL_NAME = "SmsForwarder Foreground Service"
+const val SEND_WORK_CHANNEL_ID = "cn.ppps.forwarder.send_work"
+const val SEND_WORK_CHANNEL_NAME = "SmsForwarder Message Forwarding"
 
 //Frp内网穿透
 const val FRPC_LIB_DOWNLOAD_URL = "https://xupdate.ppps.cn/uploads/%s/%s/libgojni.so"

--- a/app/src/main/kotlin/cn/ppps/forwarder/workers/SendWorker.kt
+++ b/app/src/main/kotlin/cn/ppps/forwarder/workers/SendWorker.kt
@@ -1,15 +1,23 @@
 package cn.ppps.forwarder.workers
 
 import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.Data
+import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.google.gson.Gson
 import cn.ppps.forwarder.R
+import cn.ppps.forwarder.activity.MainActivity
 import cn.ppps.forwarder.core.Core
 import cn.ppps.forwarder.database.entity.Logs
 import cn.ppps.forwarder.database.entity.Msg
@@ -20,6 +28,8 @@ import cn.ppps.forwarder.utils.CHECK_SIM_SLOT_ALL
 import cn.ppps.forwarder.utils.DataProvider
 import cn.ppps.forwarder.utils.HistoryUtils
 import cn.ppps.forwarder.utils.Log
+import cn.ppps.forwarder.utils.SEND_WORK_CHANNEL_ID
+import cn.ppps.forwarder.utils.SEND_WORK_CHANNEL_NAME
 import cn.ppps.forwarder.utils.SendUtils
 import cn.ppps.forwarder.utils.SettingUtils
 import cn.ppps.forwarder.utils.TASK_CONDITION_APP
@@ -43,6 +53,12 @@ class SendWorker(context: Context, params: WorkerParameters) : CoroutineWorker(c
 
         return withContext(Dispatchers.IO) {
             try {
+                val enqueuedAt = inputData.getLong(Worker.SEND_ENQUEUED_AT, 0L)
+                if (enqueuedAt > 0L) {
+                    val queueDelayMs = (System.currentTimeMillis() - enqueuedAt).coerceAtLeast(0L)
+                    Log.d(TAG, "queueDelayMs=$queueDelayMs")
+                }
+
                 val msgInfoJson = inputData.getString(Worker.SEND_MSG_INFO)
                 if (msgInfoJson.isNullOrBlank()) {
                     return@withContext Result.failure(workDataOf("send" to "msgInfoJson is null"))
@@ -118,6 +134,39 @@ class SendWorker(context: Context, params: WorkerParameters) : CoroutineWorker(c
 
             return@withContext Result.success()
         }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.createNotificationChannel(
+                NotificationChannel(
+                    SEND_WORK_CHANNEL_ID,
+                    SEND_WORK_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_LOW,
+                )
+            )
+        }
+
+        val immutableFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+        val pendingIntentFlags = PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag
+        val pendingIntent = PendingIntent.getActivity(
+            applicationContext,
+            0,
+            Intent(applicationContext, MainActivity::class.java),
+            pendingIntentFlags,
+        )
+        val notification = NotificationCompat.Builder(applicationContext, SEND_WORK_CHANNEL_ID)
+            .setContentTitle(applicationContext.getString(R.string.app_name))
+            .setContentText(applicationContext.getString(R.string.forward_sms))
+            .setSmallIcon(R.drawable.ic_forwarder)
+            .setContentIntent(pendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
+            .setOngoing(true)
+            .build()
+        val notificationId = 0x20000000 or (id.hashCode() and 0x0fffffff)
+        return ForegroundInfo(notificationId, notification)
     }
 
     private fun autoTaskProcess(msgInfo: MsgInfo, msgInfoJson: String, simSlot: String) {

--- a/app/src/test/kotlin/cn/ppps/forwarder/receiver/SmsReceiverTest.kt
+++ b/app/src/test/kotlin/cn/ppps/forwarder/receiver/SmsReceiverTest.kt
@@ -1,0 +1,24 @@
+package cn.ppps.forwarder.receiver
+
+import androidx.work.OutOfQuotaPolicy
+import cn.ppps.forwarder.utils.Worker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SmsReceiverTest {
+
+    @Suppress("RestrictedApi")
+    @Test
+    fun buildSmsSendWorkRequestCreatesExpeditedWork() {
+        val msgInfoJson = "{\"type\":\"sms\"}"
+        val enqueuedAt = 1234L
+
+        val request = buildSmsSendWorkRequest(msgInfoJson, enqueuedAt)
+
+        assertTrue(request.workSpec.expedited)
+        assertEquals(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST, request.workSpec.outOfQuotaPolicy)
+        assertEquals(msgInfoJson, request.workSpec.input.getString(Worker.SEND_MSG_INFO))
+        assertEquals(enqueuedAt, request.workSpec.input.getLong(Worker.SEND_ENQUEUED_AT, 0L))
+    }
+}


### PR DESCRIPTION
## 问题

在华为 LYA-AL00（Android 10 / EMUI 11）上复现到以下时序：

- 锁屏后收到短信时，`SMS_RECEIVED` 广播和 `msgInfo` 日志立即出现；
- `SendWorker` 没有启动，Webhook 也没有收到请求；
- 解锁触发 `USER_PRESENT` 后，之前排队的 `SendWorker` 才开始执行并完成转发。

这说明短信监听本身没有丢失，延迟发生在普通 WorkManager 任务的系统调度阶段。部分厂商系统会在锁屏/休眠期间推迟普通 JobScheduler 任务。

Related to #727.

## 修改

- 将短信转发任务标记为 expedited work，尽量在短信广播后立即运行；
- 配额不足时使用 `RUN_AS_NON_EXPEDITED_WORK_REQUEST`，避免任务被丢弃；
- 为 Android 11 及更低版本实现 `getForegroundInfo()`，让 expedited work 可以通过低优先级前台服务运行；
- 使用独立通知渠道，避免修改现有常驻服务的通知渠道；
- 记录任务入队时间和 `queueDelayMs`，方便后续定位 OEM 调度延迟；
- 增加单元测试，覆盖 expedited 标记、降级策略和输入数据。

## 验证

- `testDebugUnitTest` 通过（JDK 11）；
- `assembleDebug` 通过（JDK 11，本地 debug 签名）；
- 已在上述设备上完成修改前的锁屏/短信/解锁时序确认；由于手机现有 APK 使用不同签名，为避免卸载导致配置丢失，没有覆盖安装本地 debug APK。